### PR TITLE
refactor: remove Replit auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # growrich-e-learning
 
 ## Overview
-Growrich E-Learning is a full‑stack platform for delivering learning packs and general video content. It uses an Express backend with a React client and integrates with Replit for authentication.
+Growrich E-Learning is a full‑stack platform for delivering learning packs and general video content. It uses an Express backend with a React client and integrates with Google for authentication.
 
 ## Installation
 1. Change into the application directory
@@ -27,11 +27,11 @@ Growrich E-Learning is a full‑stack platform for delivering learning packs and
 ## Environment Variables
 Create a `.env` file or set the following variables:
 - `DATABASE_URL` – PostgreSQL connection string
-- `REPLIT_DOMAINS` – comma‑separated list of allowed domains
-- `REPL_ID` – Replit application ID
 - `SESSION_SECRET` – secret for Express session cookies
-- `ISSUER_URL` – OIDC issuer URL (optional, defaults to `https://replit.com/oidc`)
 - `PORT` – port to listen on (default `5000`)
+- `GOOGLE_CLIENT_ID` – Google OAuth client ID
+- `GOOGLE_CLIENT_SECRET` – Google OAuth client secret
+- `GOOGLE_CALLBACK_URL` – callback URL for Google OAuth (default `/api/google/callback`)
 
 ## Testing the API
 After the server is running and you have an authenticated session, you can test endpoints such as:

--- a/SawadeeBot/.env
+++ b/SawadeeBot/.env
@@ -2,18 +2,13 @@
 # Replace username, password, host, and database name with your own values
 DATABASE_URL=postgresql://username:password@localhost:5432/growrich
 
-# Comma-separated list of domains allowed to access the app via Replit auth
-# e.g. localhost,example.com
-REPLIT_DOMAINS=localhost
-
-# Replit application ID for OIDC authentication
-REPL_ID=your-replit-app-id
-
 # Secret used to sign session cookies. Generate a long random string
 SESSION_SECRET=your-session-secret
 
-# OIDC issuer URL. Change only if using a non-Replit identity provider
-ISSUER_URL=https://replit.com/oidc
+# Google OAuth credentials
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CALLBACK_URL=http://localhost:5000/api/google/callback
 
 # Port the server listens on
 PORT=5000

--- a/SawadeeBot/client/index.html
+++ b/SawadeeBot/client/index.html
@@ -10,7 +10,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
-    <script type="text/javascript" src="https://replit.com/public/js/replit-dev-banner.js"></script>
   </body>
 </html>

--- a/SawadeeBot/client/src/components/general-content.tsx
+++ b/SawadeeBot/client/src/components/general-content.tsx
@@ -12,7 +12,7 @@ export default function GeneralContent() {
     category: "",
   });
 
-  const { data: videos, isLoading } = useQuery({
+  const { data: videos, isLoading } = useQuery<any>({
     queryKey: ["/api/general-videos", filters.category, filters.position, filters.search],
   });
 

--- a/SawadeeBot/client/src/components/hero-section.tsx
+++ b/SawadeeBot/client/src/components/hero-section.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
 export default function HeroSection() {
-  const { data: dashboardData } = useQuery({
+  const { data: dashboardData } = useQuery<any>({
     queryKey: ["/api/dashboard"],
   });
 

--- a/SawadeeBot/client/src/components/structured-packs.tsx
+++ b/SawadeeBot/client/src/components/structured-packs.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import VideoCard from "./video-card";
 
 export default function StructuredPacks() {
-  const { data: packs, isLoading } = useQuery({
+  const { data: packs, isLoading } = useQuery<any>({
     queryKey: ["/api/learning-packs"],
   });
 

--- a/SawadeeBot/client/src/components/user-dashboard.tsx
+++ b/SawadeeBot/client/src/components/user-dashboard.tsx
@@ -4,11 +4,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 export default function UserDashboard() {
-  const { data: dashboardData, isLoading } = useQuery({
+  const { data: dashboardData, isLoading } = useQuery<any>({
     queryKey: ["/api/dashboard"],
   });
 
-  const { data: achievements } = useQuery({
+  const { data: achievements } = useQuery<any>({
     queryKey: ["/api/achievements"],
   });
 

--- a/SawadeeBot/client/src/hooks/useAuth.ts
+++ b/SawadeeBot/client/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 export function useAuth() {
-  const { data: user, isLoading } = useQuery({
+  const { data: user, isLoading } = useQuery<any>({
     queryKey: ["/api/auth/user"],
     retry: false,
   });

--- a/SawadeeBot/client/src/pages/home.tsx
+++ b/SawadeeBot/client/src/pages/home.tsx
@@ -20,7 +20,7 @@ export default function Home() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = "/api/login/google";
       }, 500);
       return;
     }

--- a/SawadeeBot/client/src/pages/landing.tsx
+++ b/SawadeeBot/client/src/pages/landing.tsx
@@ -31,7 +31,7 @@ export default function Landing() {
               <Button 
                 size="lg" 
                 className="bg-primary hover:bg-primary/90 text-primary-foreground px-12 py-4 text-lg font-semibold"
-                onClick={() => window.location.href = '/api/login'}
+                onClick={() => window.location.href = '/api/login/google'}
                 data-testid="button-login"
               >
                 เข้าสู่ระบบ

--- a/SawadeeBot/client/src/pages/pack-detail.tsx
+++ b/SawadeeBot/client/src/pages/pack-detail.tsx
@@ -17,7 +17,7 @@ export default function PackDetail() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
 
-  const { data: packData, isLoading } = useQuery({
+  const { data: packData, isLoading } = useQuery<any>({
     queryKey: ["/api/learning-packs", id],
     enabled: !!id,
   });
@@ -42,7 +42,7 @@ export default function PackDetail() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = "/api/login/google";
         }, 500);
         return;
       }

--- a/SawadeeBot/client/src/pages/video-player.tsx
+++ b/SawadeeBot/client/src/pages/video-player.tsx
@@ -20,7 +20,7 @@ export default function VideoPlayer() {
   const [isCompleted, setIsCompleted] = useState(false);
 
   // For pack videos, we need to get the pack info
-  const { data: packData } = useQuery({
+  const { data: packData } = useQuery<any>({
     queryKey: ["/api/learning-packs", "video", id],
     enabled: type === "pack",
     queryFn: async () => {
@@ -31,7 +31,7 @@ export default function VideoPlayer() {
   });
 
   // For general videos
-  const { data: videoData, isLoading } = useQuery({
+  const { data: videoData, isLoading } = useQuery<any>({
     queryKey: type === "general" ? ["/api/general-videos", id] : ["/api/pack-videos", id],
     enabled: !!id,
   });
@@ -53,7 +53,7 @@ export default function VideoPlayer() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = "/api/login/google";
         }, 500);
         return;
       }

--- a/SawadeeBot/overview.md
+++ b/SawadeeBot/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-LearnStream is a corporate learning management system (LMS) built with React, Express.js, and PostgreSQL. The platform provides structured learning paths and general video content for employee skill development, with comprehensive progress tracking and role-based content filtering. It features a modern dark-themed UI built with shadcn/ui components and integrates with Replit's authentication system.
+LearnStream is a corporate learning management system (LMS) built with React, Express.js, and PostgreSQL. The platform provides structured learning paths and general video content for employee skill development, with comprehensive progress tracking and role-based content filtering. It features a modern dark-themed UI built with shadcn/ui components and integrates with Google OAuth for authentication.
 
 # User Preferences
 
@@ -21,7 +21,7 @@ Preferred communication style: Simple, everyday language.
 - **Database ORM**: Drizzle ORM for type-safe database operations
 - **API Design**: RESTful endpoints with structured error handling
 - **Session Management**: Express sessions with PostgreSQL store
-- **Authentication**: Replit OAuth integration with OpenID Connect
+- **Authentication**: Google OAuth integration with OpenID Connect
 
 ## Data Storage
 - **Primary Database**: PostgreSQL with Neon serverless hosting
@@ -37,7 +37,7 @@ Preferred communication style: Simple, everyday language.
 - **Achievements**: Gamification system for learning milestones
 
 ## Authentication & Authorization
-- **Provider**: Replit OAuth with session-based authentication
+- **Provider**: Google OAuth with session-based authentication
 - **Session Management**: Secure HTTP-only cookies with PostgreSQL persistence
 - **Authorization**: Role-based access control using user position field
 - **Security**: CSRF protection and secure session configuration
@@ -52,10 +52,10 @@ Preferred communication style: Simple, everyday language.
 
 ## Database & Hosting
 - **Neon Database**: Serverless PostgreSQL hosting with connection pooling
-- **Replit Platform**: Development environment and deployment platform
+- **Hosting Platform**: Deployment environment of choice
 
 ## Authentication
-- **Replit Auth**: OAuth provider with OpenID Connect integration
+- **Google OAuth**: OAuth provider with OpenID Connect integration
 - **Session Store**: connect-pg-simple for PostgreSQL session persistence
 
 ## UI & Components

--- a/SawadeeBot/package-lock.json
+++ b/SawadeeBot/package-lock.json
@@ -77,8 +77,6 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
-        "@replit/vite-plugin-cartographer": "^0.3.0",
-        "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
         "@types/connect-pg-simple": "^7.0.3",
@@ -2700,28 +2698,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
-    },
-    "node_modules/@replit/vite-plugin-cartographer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@replit/vite-plugin-cartographer/-/vite-plugin-cartographer-0.3.0.tgz",
-      "integrity": "sha512-sCeHU694gqRKtUHpLSNiRDpsOW6ppMvXjCgCDAHQicgdQjTr3TKZkZLZPtUZfR7iIThmFMf3T0O+wZE06rXfzQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
-        "magic-string": "^0.30.12",
-        "modern-screenshot": "^4.6.0"
-      }
-    },
-    "node_modules/@replit/vite-plugin-runtime-error-modal": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@replit/vite-plugin-runtime-error-modal/-/vite-plugin-runtime-error-modal-0.0.3.tgz",
-      "integrity": "sha512-4wZHGuI9W4o9p8g4Ma/qj++7SP015+FMDGYobj7iap5oEsxXMm0B02TO5Y5PW8eqBPd4wX5l3UGco/hlC0qapw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.24.4",
@@ -6173,15 +6149,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6341,12 +6308,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
-    },
-    "node_modules/modern-screenshot": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.6.0.tgz",
-      "integrity": "sha512-L7osQAWpJiWY1ST1elhLRSGD5i7og5uoICqiXs38whAjWtIayp3cBMJmyML4iyJcBhRfHOyciq1g1Ft5G0QvSg==",
-      "dev": true
     },
     "node_modules/motion-dom": {
       "version": "11.13.0",

--- a/SawadeeBot/package.json
+++ b/SawadeeBot/package.json
@@ -81,8 +81,6 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
-    "@replit/vite-plugin-cartographer": "^0.3.0",
-    "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@types/connect-pg-simple": "^7.0.3",

--- a/SawadeeBot/server/routes.ts
+++ b/SawadeeBot/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { setupAuth, isAuthenticated } from "./replitAuth";
+import { setupAuth, isAuthenticated } from "./auth";
 import { 
   insertLearningPackSchema,
   insertPackVideoSchema,

--- a/SawadeeBot/server/storage.ts
+++ b/SawadeeBot/server/storage.ts
@@ -25,7 +25,7 @@ import { db } from "./db";
 import { eq, and, desc, asc, count, sql } from "drizzle-orm";
 
 export interface IStorage {
-  // User operations (mandatory for Replit Auth)
+  // User operations (required for OAuth)
   getUser(id: string): Promise<User | undefined>;
   upsertUser(user: UpsertUser): Promise<User>;
   
@@ -132,11 +132,11 @@ export class DatabaseStorage implements IStorage {
       conditions.push(sql`${generalVideos.title} ILIKE ${`%${search}%`} OR ${generalVideos.description} ILIKE ${`%${search}%`}`);
     }
     
-    let query = db.select().from(generalVideos);
+    let query: any = db.select().from(generalVideos);
     if (conditions.length > 0) {
       query = query.where(and(...conditions));
     }
-    
+
     return await query.orderBy(desc(generalVideos.viewCount));
   }
 

--- a/SawadeeBot/shared/schema.ts
+++ b/SawadeeBot/shared/schema.ts
@@ -13,7 +13,7 @@ import {
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
-// Session storage table for Replit Auth
+// Session storage table for OAuth
 export const sessions = pgTable(
   "sessions",
   {
@@ -24,7 +24,7 @@ export const sessions = pgTable(
   (table) => [index("IDX_session_expire").on(table.expire)],
 );
 
-// User storage table for Replit Auth
+// User storage table for OAuth
 export const users = pgTable("users", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   email: varchar("email").unique(),

--- a/SawadeeBot/vite.config.ts
+++ b/SawadeeBot/vite.config.ts
@@ -1,20 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig({
   plugins: [
     react(),
-    runtimeErrorOverlay(),
-    ...(process.env.NODE_ENV !== "production" &&
-    process.env.REPL_ID !== undefined
-      ? [
-          await import("@replit/vite-plugin-cartographer").then((m) =>
-            m.cartographer(),
-          ),
-        ]
-      : []),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- drop Replit authentication code and rely solely on Google OAuth
- update documentation and env samples to reference Google auth only
- clean up unused Replit tooling and resolve TypeScript issues

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b7cffbb0f0832db2f1a6009f776149