### PR TITLE
chore: add root build scripts for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,14 @@
 Growrich E-Learning is a full‑stack platform for delivering learning packs and general video content. It uses an Express backend with a React client and integrates with Replit for authentication.
 
 ## Installation
-1. Change into the application directory
-   ```bash
-   cd SawadeeBot
-   ```
-2. Install dependencies
-   ```bash
-   npm install
-   ```
+Install dependencies from the repository root (this installs the application located in `SawadeeBot`):
+```bash
+npm install
+```
+You can still run `cd SawadeeBot && npm install` if you prefer to work from that directory.
 
 ## Running
+From the repository root:
 - **Development**
   ```bash
   npm run dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "growrich-e-learning",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "growrich-e-learning",
+      "hasInstallScript": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "growrich-e-learning",
+  "private": true,
+  "scripts": {
+    "install": "cd SawadeeBot && npm install",
+    "build": "npm --prefix SawadeeBot run build",
+    "start": "npm --prefix SawadeeBot start",
+    "dev": "npm --prefix SawadeeBot run dev",
+    "test": "npm --prefix SawadeeBot test"
+  }
+}


### PR DESCRIPTION
## Summary
- add root `package.json` that proxies npm scripts to `SawadeeBot`
- document root-level workflow in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d87a77f8832d9b5831e7668b4ae3