### PR TITLE
fix: use esbuild for server build

### DIFF
--- a/SawadeeBot/package.json
+++ b/SawadeeBot/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build:client": "vite build",
+    "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "npm run build:client && npm run build:server",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- split client and server build steps
- use esbuild to bundle `server/index.ts`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b81fdb3010832dabb18f25aa57cd32