### PR TITLE
fix: align Google callback route

### DIFF
--- a/SawadeeBot/server/replitAuth.ts
+++ b/SawadeeBot/server/replitAuth.ts
@@ -91,7 +91,7 @@ export async function setupAuth(app: Express) {
         name: `replitauth:${domain}`,
         config,
         scope: "openid email profile offline_access",
-        callbackURL: `https://${domain}/api/callback`,
+        callbackURL: `https://${domain}/auth/google/callback`,
       },
       verify,
     );
@@ -108,7 +108,7 @@ export async function setupAuth(app: Express) {
     })(req, res, next);
   });
 
-  app.get("/api/callback", (req, res, next) => {
+  app.get("/auth/google/callback", (req, res, next) => {
     passport.authenticate(`replitauth:${req.hostname}`, {
       successReturnToOrRedirect: "/",
       failureRedirect: "/api/login",


### PR DESCRIPTION
## Summary
- adjust passport callbackURL and Express route to use `/auth/google/callback`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85ba73db0832dafddf23ca763a74a