### PR TITLE
Remove offline_access scope and request refresh token via access_type

### DIFF
--- a/SawadeeBot/server/replitAuth.ts
+++ b/SawadeeBot/server/replitAuth.ts
@@ -90,7 +90,7 @@ export async function setupAuth(app: Express) {
       {
         name: `replitauth:${domain}`,
         config,
-        scope: "openid email profile offline_access",
+        scope: "openid email profile",
         callbackURL: `https://${domain}/auth/google/callback`,
       },
       verify,
@@ -103,8 +103,9 @@ export async function setupAuth(app: Express) {
 
   app.get("/api/login", (req, res, next) => {
     passport.authenticate(`replitauth:${req.hostname}`, {
-      prompt: "login consent",
-      scope: ["openid", "email", "profile", "offline_access"],
+      scope: ["openid", "email", "profile"],
+      access_type: "offline",
+      prompt: "consent",
     })(req, res, next);
   });
 


### PR DESCRIPTION
## Summary
- remove `offline_access` from Replit OAuth scopes
- request refresh token using `access_type=offline` and `prompt=consent`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85f418540832d9c653b5e2defb927