### PR TITLE
feat: add passport oauth20 types

### DIFF
--- a/SawadeeBot/package.json
+++ b/SawadeeBot/package.json
@@ -94,6 +94,7 @@
     "@types/node": "20.16.11",
     "@types/passport": "^1.0.16",
     "@types/passport-local": "^1.0.38",
+    "@types/passport-google-oauth20": "^2.0.11",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.5.13",

--- a/SawadeeBot/server/auth.ts
+++ b/SawadeeBot/server/auth.ts
@@ -2,7 +2,8 @@ import passport from "passport";
 import session from "express-session";
 import type { Express, RequestHandler } from "express";
 import connectPg from "connect-pg-simple";
-import { Strategy as GoogleStrategy, Profile } from "passport-google-oauth20";
+import { Strategy as GoogleStrategy } from "passport-google-oauth20";
+import type { Profile } from "passport-google-oauth20";
 import { storage } from "./storage";
 
 export function getSession() {


### PR DESCRIPTION
## Summary
- add @types/passport-google-oauth20 dev dependency
- improve auth imports by using type-only Profile import

## Testing
- `npm --prefix SawadeeBot install passport-google-oauth20` *(fails: 403 Forbidden)*
- `npm --prefix SawadeeBot install -D @types/passport-google-oauth20` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b878811300832dabeb4e60e7ce9206