### PR TITLE
Integrate Google OAuth router with Passport

### DIFF
--- a/SawadeeBot/server/index.ts
+++ b/SawadeeBot/server/index.ts
@@ -1,10 +1,29 @@
 import express, { type Request, Response, NextFunction } from "express";
+import session from "express-session";
+import passport from "passport";
+import path from "path";
+import authRouter from "./auth";
 import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
+import { setupVite, log } from "./vite";
 
 const app = express();
+
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET!,
+    resave: false,
+    saveUninitialized: false,
+    cookie: { sameSite: "lax", secure: "auto" },
+  })
+);
+
+app.use(passport.initialize());
+app.use(passport.session());
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+
+app.use("/auth", authRouter);
 
 app.use((req, res, next) => {
   const start = Date.now();
@@ -36,6 +55,8 @@ app.use((req, res, next) => {
   next();
 });
 
+const staticDir = path.join(process.cwd(), "dist", "public");
+
 (async () => {
   const server = await registerRoutes(app);
 
@@ -47,25 +68,25 @@ app.use((req, res, next) => {
     throw err;
   });
 
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
   if (app.get("env") === "development") {
     await setupVite(app, server);
   } else {
-    serveStatic(app);
+    app.use(express.static(staticDir));
   }
 
-  // ALWAYS serve the app on the port specified in the environment variable PORT
-  // Other ports are firewalled. Default to 5000 if not specified.
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = parseInt(process.env.PORT || '5000', 10);
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
-    log(`serving on port ${port}`);
+  app.get("*", (_req, res) => {
+    res.sendFile(path.join(staticDir, "index.html"));
   });
+
+  const port = parseInt(process.env.PORT || "5000", 10);
+  server.listen(
+    {
+      port,
+      host: "0.0.0.0",
+      reusePort: true,
+    },
+    () => {
+      log(`serving on port ${port}`);
+    }
+  );
 })();

--- a/SawadeeBot/server/routes.ts
+++ b/SawadeeBot/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { setupAuth, isAuthenticated } from "./auth";
+import { isAuthenticated } from "./auth";
 import { 
   insertLearningPackSchema,
   insertPackVideoSchema,
@@ -13,9 +13,6 @@ import {
 import { z } from "zod";
 
 export async function registerRoutes(app: Express): Promise<Server> {
-  // Auth middleware
-  await setupAuth(app);
-
   // Auth routes
   app.get('/api/auth/user', isAuthenticated, async (req: any, res) => {
     try {


### PR DESCRIPTION
## Summary
- add Google OAuth Passport strategy and router for login, callback, user info, and logout
- mount auth router at `/auth` with session and Passport initialization
- streamline routes to rely on exported `isAuthenticated` middleware

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b881d64ec4832d94ddf980b1889fe4