### PR TITLE
feat: configure session and cors middleware before routes

### DIFF
--- a/SawadeeBot/server/index.ts
+++ b/SawadeeBot/server/index.ts
@@ -11,16 +11,14 @@ import { setupVite, log } from "./vite";
 
 const app = express();
 
-// 1) proxy & body parser
 app.set("trust proxy", 1);
 app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
 
-// 2) CORS
-const ORIGIN = process.env.CLIENT_ORIGIN || "http://localhost:5173";
+// อนุญาต cross-origin
+const ORIGIN = process.env.CLIENT_ORIGIN || "https://<frontend-domain>";
 app.use(cors({ origin: ORIGIN, credentials: true }));
 
-// 3) Redis session
+// ใช้ Redis store จาก Upstash
 const redis = new Redis(process.env.REDIS_URL);
 const RedisStore = RedisStoreFactory(session);
 
@@ -33,12 +31,14 @@ app.use(
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      maxAge: 1000 * 60 * 60 * 24 * 7,
-      secure: true,
-      sameSite: "none",
+      maxAge: 1000 * 60 * 60 * 24 * 7, // 7 วัน
+      secure: true,     // ใช้ HTTPS → ต้อง true
+      sameSite: "none", // ถ้าข้ามโดเมน
     },
   })
 );
+
+app.use(express.urlencoded({ extended: false }));
 
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
## Summary
- initialize express app with CORS and Redis-backed session before all routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b6981144832db150dc177fa8e13d